### PR TITLE
fix(stat-tables): vertically center the drop rate and graph in two st…

### DIFF
--- a/src/views/Stats/Item.vue
+++ b/src/views/Stats/Item.vue
@@ -153,19 +153,21 @@
             <td class="text-xs-right">
               {{ props.item.quantity }}
             </td>
-            <td class="text-xs-right charts-data-wrapper">
-              {{ props.item.percentageText }}
-              <Charts
-                v-if="getStageItemTrend(props.item.stage.stageId)"
-                :interval="getStageItemTrendInterval(props.item.stage.stageId)"
-                :x-start="getStageItemTrendStartTime(props.item.stage.stageId)"
-                :show-dialog="expanded[props.item.stage.stageId]"
-                :data-keys="['quantity']"
-                sparkline-key="quantity"
-                sparkline-sub-key="times"
-                :data="getStageItemTrendResults(props.item.stage.stageId)"
-                :charts-id="props.item.stage.stageId"
-              />
+            <td class="text-xs-right">
+              <div class="charts-data-wrapper">
+                {{ props.item.percentageText }}
+                <Charts
+                  v-if="getStageItemTrend(props.item.stage.stageId)"
+                  :interval="getStageItemTrendInterval(props.item.stage.stageId)"
+                  :x-start="getStageItemTrendStartTime(props.item.stage.stageId)"
+                  :show-dialog="expanded[props.item.stage.stageId]"
+                  :data-keys="['quantity']"
+                  sparkline-key="quantity"
+                  sparkline-sub-key="times"
+                  :data="getStageItemTrendResults(props.item.stage.stageId)"
+                  :charts-id="props.item.stage.stageId"
+                />
+              </div>
             </td>
             <td class="text-xs-right">
               {{ props.item.apPPR }}

--- a/src/views/Stats/Stage.vue
+++ b/src/views/Stats/Stage.vue
@@ -298,19 +298,21 @@
                 <td class="text-xs-right">
                   {{ props.item.quantity }}
                 </td>
-                <td class="text-xs-right charts-data-wrapper">
-                  {{ props.item.percentageText }}
-                  <Charts
-                    v-if="currentTrends"
-                    :interval="currentTrends && currentTrends.interval"
-                    :x-start="currentTrends && currentTrends.startTime"
-                    :show-dialog="expanded[props.item.item.itemId]"
-                    :data-keys="['quantity']"
-                    sparkline-key="quantity"
-                    sparkline-sub-key="times"
-                    :data="currentTrendsData && currentTrendsData[props.item.item.itemId]"
-                    :charts-id="props.item.item.itemId"
-                  />
+                <td class="text-xs-right">
+                  <div class="charts-data-wrapper">
+                    {{ props.item.percentageText }}
+                    <Charts
+                      v-if="currentTrends"
+                      :interval="currentTrends && currentTrends.interval"
+                      :x-start="currentTrends && currentTrends.startTime"
+                      :show-dialog="expanded[props.item.item.itemId]"
+                      :data-keys="['quantity']"
+                      sparkline-key="quantity"
+                      sparkline-sub-key="times"
+                      :data="currentTrendsData && currentTrendsData[props.item.item.itemId]"
+                      :charts-id="props.item.item.itemId"
+                    />
+                  </div>
                 </td>
                 <td class="text-xs-right">
                   {{ props.item.apPPR }}


### PR DESCRIPTION
…at tables

use a div to wrap the rate text and chart, so that it will not affect td's padding

fix #42