### PR TITLE
fix(stats-table): refine stats tables in the two result pages

### DIFF
--- a/src/views/Stats/Item.vue
+++ b/src/views/Stats/Item.vue
@@ -116,10 +116,16 @@
 
           must-sort
           hide-actions
-          class="elevation-0 transparentTable"
+          class="elevation-0 transparentTable stat-table"
+          :calculate-widths="true"
         >
           <template v-slot:items="props">
-            <td>
+            <td
+              :class="{
+                'px-3': $vuetify.breakpoint.xsOnly,
+                'stage-code-td-xs': $vuetify.breakpoint.xsOnly
+              }"
+            >
               <span
                 class="cursor-pointer"
                 @click="redirectStage(props.item)"
@@ -143,16 +149,28 @@
                 </v-hover>
               </span>
             </td>
-            <td class="text-xs-right">
+            <td
+              class="text-xs-center"
+              :class="{'px-3': $vuetify.breakpoint.xsOnly}"
+            >
               {{ props.item.stage.apCost }}
             </td>
-            <td class="text-xs-right">
+            <td
+              class="text-xs-center"
+              :class="{'px-3': $vuetify.breakpoint.xsOnly}"
+            >
               {{ props.item.times }}
             </td>
-            <td class="text-xs-right">
+            <td
+              class="text-xs-center"
+              :class="{'px-3': $vuetify.breakpoint.xsOnly}"
+            >
               {{ props.item.quantity }}
             </td>
-            <td class="text-xs-right">
+            <td
+              class="text-xs-center"
+              :class="{'px-3': $vuetify.breakpoint.xsOnly}"
+            >
               <div class="charts-data-wrapper">
                 {{ props.item.percentageText }}
                 <div
@@ -173,7 +191,10 @@
                 </div>
               </div>
             </td>
-            <td class="text-xs-right">
+            <td
+              class="text-xs-center"
+              :class="{'px-3': $vuetify.breakpoint.xsOnly}"
+            >
               {{ props.item.apPPR }}
             </td>
           </template>
@@ -228,42 +249,37 @@
             value: "icon",
             align: "center",
             sortable: false,
-            width: "200"
+            width: "250px"
           },
           {
             text: this.$t('stats.headers.apCost'),
             value: "stage.apCost",
             align: "center",
             sortable: true,
-            width: "30",
           },
           {
             text: this.$t('stats.headers.times'),
             value: "times",
             align: "center",
-            sortable: true,
-            width: "30",
+            sortable: true
           },
           {
             text: this.$t('stats.headers.quantity'),
             value: "quantity",
             align: "center",
-            sortable: true,
-            width: "30",
+            sortable: true
           },
           {
             text: this.$t('stats.headers.percentage'),
             value: "percentage",
             align: "center",
-            sortable: true,
-            width: "1"
+            sortable: true
           },
           {
             text: this.$t('stats.headers.apPPR'),
             value: "apPPR",
             align: "center",
-            sortable: true,
-            width: "1"
+            sortable: true
           }
         ]
       },
@@ -359,7 +375,7 @@
   }
   .charts-data-wrapper {
     display: flex;
-    justify-content: flex-end;
+    justify-content: center;
     align-items: center;
   }
   .charts-wrapper {
@@ -382,5 +398,15 @@
     align-items: center;
     min-width: 62px;
     margin: 4px 0;
+  }
+  >>>.stat-table th {
+    padding-left: 8px !important;
+    padding-right: 8px !important;
+  }
+  >>>.stat-table th i {
+    margin-left: -16px;
+  }
+  .stage-code-td-xs {
+    min-width: 122px;
   }
 </style>

--- a/src/views/Stats/Stage.vue
+++ b/src/views/Stats/Stage.vue
@@ -266,13 +266,19 @@
 
           must-sort
           hide-actions
-          class="elevation-0 transparentTable"
+          class="elevation-0 transparentTable stat-table"
+          :calculate-widths="true"
         >
           <template v-slot:items="props">
             <tr>
               <td
                 class="hovering"
-                :class="{ 'hovering--hovered': hover }"
+                :class="{ 
+                  'hovering--hovered': hover, 
+                  'px-3': $vuetify.breakpoint.smAndDown,
+                  'item-name-td-xs': $vuetify.breakpoint.xsOnly,
+                  'item-name-td-sm': $vuetify.breakpoint.smOnly
+                }"
               >
                 <span
                   class="cursor-pointer"
@@ -291,10 +297,15 @@
                           disable-link
                         />
                       </v-avatar>
-                      {{ props.item.item.name }}
+                      <span
+                        v-if="!$vuetify.breakpoint.xsOnly"
+                        class="ml-2"
+                      >
+                        {{ props.item.item.name }}
+                      </span>
                       <v-slide-x-transition>
                         <v-icon
-                          v-if="hover || $vuetify.breakpoint.smAndDown"
+                          v-if="hover || $vuetify.breakpoint.smOnly"
                           small
                         >mdi-chevron-right</v-icon>
                       </v-slide-x-transition>
@@ -302,13 +313,22 @@
                   </v-hover>
                 </span>
               </td>
-              <td class="text-xs-right">
+              <td
+                class="text-xs-center"
+                :class="{'px-3': $vuetify.breakpoint.xsOnly}"
+              >
                 {{ props.item.times }}
               </td>
-              <td class="text-xs-right">
+              <td
+                class="text-xs-center"
+                :class="{'px-3': $vuetify.breakpoint.xsOnly}"
+              >
                 {{ props.item.quantity }}
               </td>
-              <td class="text-xs-right">
+              <td
+                class="text-xs-center"
+                :class="{'px-3': $vuetify.breakpoint.xsOnly}"
+              >
                 <div 
                   class="charts-data-wrapper"
                   fill-height
@@ -332,7 +352,10 @@
                   </div>
                 </div>
               </td>
-              <td class="text-xs-right">
+              <td
+                class="text-xs-center"
+                :class="{'px-3': $vuetify.breakpoint.xsOnly}"
+              >
                 {{ props.item.apPPR }}
               </td>
             </tr>
@@ -407,35 +430,31 @@
             value: "icon",
             align: "center",
             sortable: false,
-            width: 300
+            width: "250px"
           },
           {
             text: this.$t('stats.headers.times'),
             value: "times",
             align: "center",
-            sortable: true,
-            width: 40,
+            sortable: true
           },
           {
             text: this.$t('stats.headers.quantity'),
             value: "quantity",
             align: "center",
-            sortable: true,
-            width: 40,
+            sortable: true
           },
           {
             text: this.$t('stats.headers.percentage'),
             value: "percentage",
             align: "center",
-            sortable: true,
-            width: 65
+            sortable: true
           },
           {
             text: this.$t('stats.headers.apPPR'),
             value: "apPPR",
             align: "center",
-            sortable: true,
-            width: 80
+            sortable: true
           }
         ]
       }
@@ -518,12 +537,29 @@
 
   .charts-data-wrapper {
     display: flex;
-    justify-content: flex-end;
+    justify-content: center;
     align-items: center;
   }
 
   .charts-wrapper {
     display: flex;
     align-items: center;
+  }
+
+  >>>.stat-table th {
+    padding-left: 8px !important;
+    padding-right: 8px !important;
+  }
+
+  .item-name-td-xs {
+    min-width: 100px;
+  }
+
+  .item-name-td-sm {
+    min-width: 160px;
+  }
+
+  >>>.stat-table th i {
+    margin-left: -16px;
   }
 </style>


### PR DESCRIPTION
1. Decrease px for each column in mobile view;
2. Remove useless width in header except for the first column;
3. Make content center instead of right;
4. Move every header(except for the first one) left slightly, otherwise the invisible sorting mark will make the header not center;
5. Hide item name in stats table when the device is xs.

fix #11