### PR TITLE
fix(index.html): #120 use async loading css temporarily

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,7 @@
     <meta name="msapplication-config" content="<%= BASE_URL %>assets/favicon/browserconfig.xml">
     <meta name="theme-color" content="#ffffff">
     <title>明日方舟素材掉落统计</title>
-    <link href="https://cdn.bootcss.com/MaterialDesign-Webfont/3.8.95/css/materialdesignicons.min.css" rel="stylesheet">
+    <link href="https://cdn.bootcss.com/MaterialDesign-Webfont/3.8.95/css/materialdesignicons.min.css" rel="preload" as="style" onload="this.rel='stylesheet'">
   </head>
   <body>
     <noscript>


### PR DESCRIPTION
a temp fix for #120

To fully address the slow loading issue, need to handle the css serving method.
For now, using async loading, the icon will not be visible before the css is loaded, but at least it will not block the page loading.