### PR TITLE
Fix #119: add color attribute for undo button.

### DIFF
--- a/src/views/Report.vue
+++ b/src/views/Report.vue
@@ -162,6 +162,7 @@
       {{ $t('report.success') }}
       <v-btn
         :loading="undoing"
+        color="primary"
         @click="undo"
       >
         {{ $t('report.undo') }}


### PR DESCRIPTION
Add `color="primary"` for undo button in report view.

Fixed #119.

CAUTION: Though pretty sure this will work, I've not actually tested this fix due to failure in setting up my own development environment. Some reviewer SHOULD test it before merging.