### PR TITLE
improvement(sprite): update sprite to latest version

### DIFF
--- a/src/components/global/ItemIcon.vue
+++ b/src/components/global/ItemIcon.vue
@@ -64,13 +64,13 @@ export default {
       resolutions: {
         high: {
           iconSize: 183,
-          dimensions: [1098, 3294],
-          url: "/sprite/sprite.202310090008.png",
+          dimensions: [1098, 3477],
+          url: "/sprite/sprite.202512222028.png",
         },
         low: {
           iconSize: 183 / 2,
-          dimensions: [1098 / 2, 3294 / 2],
-          url: "/sprite/sprite.202310090008.small.png",
+          dimensions: [1098 / 2, 3477 / 2],
+          url: "/sprite/sprite.202512222028.small.png",
         },
       },
     };

--- a/src/components/global/ItemIcon.vue
+++ b/src/components/global/ItemIcon.vue
@@ -65,12 +65,12 @@ export default {
         high: {
           iconSize: 183,
           dimensions: [1098, 3477],
-          url: "/sprite/sprite.202512222028.png",
+          url: "/sprite/sprite.202512231118.png",
         },
         low: {
           iconSize: 183 / 2,
           dimensions: [1098 / 2, 3477 / 2],
-          url: "/sprite/sprite.202512222028.small.png",
+          url: "/sprite/sprite.202512231118.small.png",
         },
       },
     };


### PR DESCRIPTION
更新雪碧图，增加了手性屈光体、类凝结核的图标，见 PR 附件。
12.23 Edit: 已更正新加2个图标的先后顺序


<img width="1098" height="3477" alt="sprite 202512231118" src="https://github.com/user-attachments/assets/5ac63eed-53d0-4ef8-b797-bbc0bb758128" />
<img width="549" height="1739" alt="sprite 202512231118 small" src="https://github.com/user-attachments/assets/52a9aa7c-975c-40be-b09e-8a45dc2e2d35" />


